### PR TITLE
Update grasp dependency to beta to support ES2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Unlicensed",
   "dependencies": {
     "browserify-transform-tools": "^1.3.0",
-    "grasp": "^0.3"
+    "grasp": "^0.4.0-beta1"
   },
   "devDependencies": {
     "mocha": "^2.1.0",


### PR DESCRIPTION
Hi there, ES2015 is fairly prevalent. Grasp only supports it in 0.4.0 and above, which is currently in beta. I'm proposing to update the "grasp" dependency version to ^0.4.0-beta1 to support ES2015. Thanks
